### PR TITLE
dartsass-rails compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ gem 'active_bootstrap_skin',
 
 ```scss
 // Active Admin's got SASS!
-// @use "active_admin/mixins";
-// @use "active_admin/base";
+// @import "active_admin/mixins";
+// @import "active_admin/base";
 
 // Active Bootstrap
-@use "bootstrap-sprockets";
-@use "active_bootstrap_skin";
+@import "bootstrap-sprockets-dartsass"; // <-- add this line if you use dartsass-rails
+@import "active_bootstrap_skin";
 ```
 
 - In the `active_admin.js` file, you require `active_bootstrap_skin`.

--- a/app/assets/stylesheets/_bootstrap-sprockets-dartsass.scss
+++ b/app/assets/stylesheets/_bootstrap-sprockets-dartsass.scss
@@ -1,0 +1,19 @@
+// Compatibility helper functions for sprockets in conjunction with dartsass-rails.
+//
+// If you use dartsass-rails, add '@import "bootstrap-sprockets-dartsass";'
+// before you import bootstrap (i.e. in this case before you import active_bootstrap_skin).
+//
+// These helpers work similar to the "bootstrap-sprockets" helpers but differ in the way that
+// dartsass-rails can't process "asset-path()" and similar functions; it relies
+// on sprockets-rails to preprocess url() function contents with correct & fingerprinted
+// paths (see also sprockets-rails' config.assets.resolve_assets_in_css_urls option).
+
+@function twbs-font-path($path) {
+  @return $path
+}
+
+@function twbs-image-path($path) {
+  @return $path
+}
+
+$bootstrap-sass-asset-helper: true;

--- a/app/assets/stylesheets/_themify_icons.sass
+++ b/app/assets/stylesheets/_themify_icons.sass
@@ -3,8 +3,8 @@
 @mixin font_face($family, $path, $svg, $weight: normal, $style: normal)
   @font-face
     font-family: $family
-    src: asset-url('#{$path}.eot')
-    src: asset-url('#{$path}.eot?#iefix') format('embedded-opentype'), asset-url('#{$path}.woff') format('woff'), asset-url('#{$path}.ttf') format('truetype'), asset-url('#{$path}.svg##{$svg}') format('svg')
+    src: url('#{$path}.eot')
+    src: url('#{$path}.eot?#iefix') format('embedded-opentype'), url('#{$path}.woff') format('woff'), url('#{$path}.ttf') format('truetype'), url('#{$path}.svg##{$svg}') format('svg')
     font-weight: $weight
     font-style: $style
 


### PR DESCRIPTION
* fix README: use "@import" instead of "@use" (otherwise things seem to be broken; possibly revisit this topic later since "@import" is supposed to be deprecated)
* add "_bootstrap-sprockets-dartsass.scss" compatibility for bootstrap-sass
* change SASS "asset-url()" to "url()" calls since sprockets-rails only resolves url() correctly and not e.g. asset-/font-url() etc. (and dart sass doesn't process these rails specific functions either).